### PR TITLE
Enh: add additional fields in responses

### DIFF
--- a/rating_agent/graphql/agent.py
+++ b/rating_agent/graphql/agent.py
@@ -72,6 +72,10 @@ class BeginTransactionResponse(graphene.ObjectType):
     """Begin transaction response"""
 
     ok = graphene.Boolean()
+    tenant = graphene.ID(default_value='default')
+    transaction_tag = graphene.String(required=True)
+    account_tag = graphene.String()
+    destination_account_tag = graphene.String()
 
 
 class beginTransaction(graphene.Mutation):
@@ -119,6 +123,10 @@ class EndTransactionResponse(graphene.ObjectType):
     """End transaction response"""
 
     ok = graphene.Boolean()
+    tenant = graphene.ID(default_value='default')
+    transaction_tag = graphene.String(required=True)
+    account_tag = graphene.String()
+    destination_account_tag = graphene.String()
 
 
 class endTransaction(graphene.Mutation):
@@ -160,6 +168,10 @@ class RollbackTransactionResponse(graphene.ObjectType):
     """Rollback transaction response"""
 
     ok = graphene.Boolean()
+    tenant = graphene.ID(default_value='default')
+    transaction_tag = graphene.String(required=True)
+    account_tag = graphene.String()
+    destination_account_tag = graphene.String()
 
 
 class rollbackTransaction(graphene.Mutation):
@@ -198,6 +210,10 @@ class RecordTransactionResponse(graphene.ObjectType):
     """Record transaction response"""
 
     ok = graphene.Boolean()
+    tenant = graphene.ID(default_value='default')
+    transaction_tag = graphene.String(required=True)
+    account_tag = graphene.String()
+    destination_account_tag = graphene.String()
 
 
 class recordTransaction(graphene.Mutation):

--- a/rating_agent/schema/agent.py
+++ b/rating_agent/schema/agent.py
@@ -49,6 +49,10 @@ class BeginTransactionResponse(BaseModel):
     """Begin transaction response"""
 
     ok: bool = False
+    tenant: str = 'default'
+    transaction_tag: str
+    account_tag: Optional[str] = None
+    destination_account_tag: Optional[str] = None
 
 
 class EndTransactionRequest(BaseModel):
@@ -65,6 +69,10 @@ class EndTransactionResponse(BaseModel):
     """Begin transaction response"""
 
     ok: bool = False
+    tenant: str = 'default'
+    transaction_tag: str
+    account_tag: Optional[str] = None
+    destination_account_tag: Optional[str] = None
 
 
 class RollbackTransactionRequest(BaseModel):
@@ -80,6 +88,10 @@ class RollbackTransactionResponse(BaseModel):
     """Begin transaction response"""
 
     ok: bool = False
+    tenant: str = 'default'
+    transaction_tag: str
+    account_tag: Optional[str] = None
+    destination_account_tag: Optional[str] = None
 
 
 class RecordTransactionRequest(BaseModel):
@@ -102,3 +114,7 @@ class RecordTransactionResponse(BaseModel):
     """Record transaction response"""
 
     ok: bool = False
+    tenant: str = 'default'
+    transaction_tag: str
+    account_tag: Optional[str] = None
+    destination_account_tag: Optional[str] = None

--- a/rating_agent/services/agent.py
+++ b/rating_agent/services/agent.py
@@ -17,7 +17,13 @@ async def authorization(
         )
         or {}
     )
-    return schema.AuthorizationResponse(**response)
+    return schema.AuthorizationResponse(
+        tenant=request.tenant,
+        transaction_tag=request.transaction_tag,
+        account_tag=request.account_tag,
+        destination_account_tag=request.destination_account_tag,
+        **response
+    )
 
 
 async def begin_transaction(
@@ -31,7 +37,13 @@ async def begin_transaction(
         )
         or {}
     )
-    return schema.BeginTransactionResponse(**response)
+    return schema.BeginTransactionResponse(
+        tenant=request.tenant,
+        transaction_tag=request.transaction_tag,
+        account_tag=request.account_tag,
+        destination_account_tag=request.destination_account_tag,
+        **response
+    )
 
 
 async def end_transaction(
@@ -45,7 +57,13 @@ async def end_transaction(
         )
         or {}
     )
-    return schema.EndTransactionResponse(**response)
+    return schema.EndTransactionResponse(
+        tenant=request.tenant,
+        transaction_tag=request.transaction_tag,
+        account_tag=request.account_tag,
+        destination_account_tag=request.destination_account_tag,
+        **response
+    )
 
 
 async def rollback_transaction(
@@ -59,7 +77,13 @@ async def rollback_transaction(
         )
         or {}
     )
-    return schema.RollbackTransactionResponse(**response)
+    return schema.RollbackTransactionResponse(
+        tenant=request.tenant,
+        transaction_tag=request.transaction_tag,
+        account_tag=request.account_tag,
+        destination_account_tag=request.destination_account_tag,
+        **response
+    )
 
 
 async def record_transaction(
@@ -73,4 +97,10 @@ async def record_transaction(
         )
         or {}
     )
-    return schema.RecordTransactionResponse(**response)
+    return schema.RecordTransactionResponse(
+        tenant=request.tenant,
+        transaction_tag=request.transaction_tag,
+        account_tag=request.account_tag,
+        destination_account_tag=request.destination_account_tag,
+        **response
+    )

--- a/rating_agent/tests/test_api_authorization.py
+++ b/rating_agent/tests/test_api_authorization.py
@@ -17,15 +17,15 @@ def test_api_authorization_rest(client, engine):
     )
     assert response.status_code == 200
     assert response.json() == {
-        'account_tag': None,
+        'account_tag': '1000',
         'authorized': True,
         'authorized_destination': False,
         'balance': 0,
         'carriers': [],
-        'destination_account_tag': None,
+        'destination_account_tag': '1001',
         'max_available_units': 0,
         'tenant': 'default',
-        'transaction_tag': None,
+        'transaction_tag': '100',
         'unauthorized_account_reason': None,
         'unauthorized_account_tag': None,
         'unauthorized_destination_reason': None,

--- a/rating_agent/tests/test_api_begin_transaction.py
+++ b/rating_agent/tests/test_api_begin_transaction.py
@@ -16,7 +16,13 @@ def test_api_begin_transaction_rest(client, engine):
         ),
     )
     assert response.status_code == 200
-    assert response.json() == {'ok': True}
+    assert response.json() == {
+        'ok': True,
+        'tenant': 'default',
+        'transaction_tag': '100',
+        'account_tag': '1000',
+        'destination_account_tag': '1001',
+    }
 
 
 def test_api_begin_transaction_graphql(client, engine):
@@ -36,10 +42,22 @@ mutation {
         destination: "sip:10.0.0.2:5060"
     ) {
         ok
+        tenant
+        transaction_tag
+        account_tag
+        destination_account_tag
     }
 }"""
         },
     )
     assert response.status_code == 200
-    expected = {"beginTransaction": {"ok": True}}
+    expected = {
+        "beginTransaction": {
+            "ok": True,
+            "tenant": "default",
+            "transaction_tag": "100",
+            "account_tag": "1000",
+            "destination_account_tag": "1001",
+        }
+    }
     assert response.json()["data"] == expected

--- a/rating_agent/tests/test_api_end_transaction.py
+++ b/rating_agent/tests/test_api_end_transaction.py
@@ -16,7 +16,13 @@ def test_api_end_transaction_rest(client, engine):
         ),
     )
     assert response.status_code == 200
-    assert response.json() == {'ok': True}
+    assert response.json() == {
+        'ok': True,
+        'tenant': 'default',
+        'transaction_tag': '100',
+        'account_tag': '1000',
+        'destination_account_tag': '1001',
+    }
 
 
 def test_api_end_transaction_graphql(client, engine):
@@ -34,10 +40,22 @@ mutation {
         destination_account_tag: "1001"
     ) {
         ok
+        tenant
+        transaction_tag
+        account_tag
+        destination_account_tag
     }
 }"""
         },
     )
     assert response.status_code == 200
-    expected = {"endTransaction": {"ok": True}}
+    expected = {
+        "endTransaction": {
+            "ok": True,
+            "tenant": "default",
+            "transaction_tag": "100",
+            "account_tag": "1000",
+            "destination_account_tag": "1001",
+        }
+    }
     assert response.json()["data"] == expected

--- a/rating_agent/tests/test_api_record_transaction.py
+++ b/rating_agent/tests/test_api_record_transaction.py
@@ -16,7 +16,13 @@ def test_api_record_transaction_rest(client, engine):
         ),
     )
     assert response.status_code == 200
-    assert response.json() == {'ok': True}
+    assert response.json() == {
+        'ok': True,
+        'tenant': 'default',
+        'transaction_tag': '100',
+        'account_tag': '1000',
+        'destination_account_tag': '1001',
+    }
 
 
 def test_api_record_transaction_graphql(client, engine):
@@ -36,10 +42,22 @@ mutation {
         destination: "sip:10.0.0.2:5060"
     ) {
         ok
+        tenant
+        transaction_tag
+        account_tag
+        destination_account_tag
     }
 }"""
         },
     )
     assert response.status_code == 200
-    expected = {"recordTransaction": {"ok": True}}
+    expected = {
+        "recordTransaction": {
+            "ok": True,
+            "tenant": "default",
+            "transaction_tag": "100",
+            "account_tag": "1000",
+            "destination_account_tag": "1001",
+        }
+    }
     assert response.json()["data"] == expected

--- a/rating_agent/tests/test_api_rollback_transaction.py
+++ b/rating_agent/tests/test_api_rollback_transaction.py
@@ -14,7 +14,13 @@ def test_api_rollback_transaction_rest(client, engine):
         ),
     )
     assert response.status_code == 200
-    assert response.json() == {'ok': True}
+    assert response.json() == {
+        'ok': True,
+        'tenant': 'default',
+        'transaction_tag': '100',
+        'account_tag': '1000',
+        'destination_account_tag': '1001',
+    }
 
 
 def test_api_rollback_transaction_graphql(client, engine):
@@ -32,10 +38,22 @@ mutation {
         destination_account_tag: "1001"
     ) {
         ok
+        tenant
+        transaction_tag
+        account_tag
+        destination_account_tag
     }
 }"""
         },
     )
     assert response.status_code == 200
-    expected = {"rollbackTransaction": {"ok": True}}
+    expected = {
+        "rollbackTransaction": {
+            "ok": True,
+            "tenant": "default",
+            "transaction_tag": "100",
+            "account_tag": "1000",
+            "destination_account_tag": "1001",
+        }
+    }
     assert response.json()["data"] == expected


### PR DESCRIPTION
Responses for REST API returned null values for known data like `tenant`, `transaction_tag`, `account_tag` and `destination_account_tag`.